### PR TITLE
Allow custom headers in Websocket upgrade response

### DIFF
--- a/src/ring/adapter/undertow.clj
+++ b/src/ring/adapter/undertow.clj
@@ -16,7 +16,7 @@
 (defn handle-request [websocket? exchange response-map]
   (if websocket?
     (if-let [ws-config (:undertow/websocket response-map)]
-      (->> ws-config (ws/ws-callback) (ws/ws-request exchange))
+      (->> ws-config (ws/ws-callback) (ws/ws-request exchange (:headers response-map)))
       (set-exchange-response exchange response-map))
     (set-exchange-response exchange response-map)))
 

--- a/src/ring/adapter/undertow/websocket.clj
+++ b/src/ring/adapter/undertow/websocket.clj
@@ -18,7 +18,8 @@
      WebSocketCallback]
     [io.undertow.websockets.spi WebSocketHttpExchange]
     [org.xnio ChannelListener]
-    [ring.adapter.undertow Util]))
+    [ring.adapter.undertow Util]
+    [clojure.lang IPersistentMap]))
 
 (defn ws-listener
   "Default websocket listener
@@ -72,7 +73,7 @@
         (.set (.getReceiveSetter channel) listener)
         (.resumeReceives channel)))))
 
-(defn ws-request [^HttpServerExchange exchange headers ^WebSocketConnectionCallback callback]
+(defn ws-request [^HttpServerExchange exchange ^IPersistentMap headers ^WebSocketConnectionCallback callback]
   (let [handler (WebSocketProtocolHandshakeHandler. callback)]
     (when headers
       (set-headers (.getResponseHeaders exchange) headers))

--- a/src/ring/adapter/undertow/websocket.clj
+++ b/src/ring/adapter/undertow/websocket.clj
@@ -1,5 +1,6 @@
 (ns ring.adapter.undertow.websocket
   (:refer-clojure :exclude [send])
+  (:require [ring.adapter.undertow.headers :refer [set-headers]])
   (:import
     [java.nio ByteBuffer]
     [io.undertow.server HttpServerExchange]
@@ -71,8 +72,10 @@
         (.set (.getReceiveSetter channel) listener)
         (.resumeReceives channel)))))
 
-(defn ws-request [^HttpServerExchange exchange ^WebSocketConnectionCallback callback]
+(defn ws-request [^HttpServerExchange exchange headers ^WebSocketConnectionCallback callback]
   (let [handler (WebSocketProtocolHandshakeHandler. callback)]
+    (when headers
+      (set-headers (.getResponseHeaders exchange) headers))
     (.handleRequest handler exchange)))
 
 (defn send-text


### PR DESCRIPTION
When users provide headers in their response map, they should still be sent in the response even when the response is merely a websocket upgrade response.