### PR TITLE
Resolves #10.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/ring-undertow-adapter "1.1.2"
+(defproject luminus/ring-undertow-adapter "1.1.3"
   :description "Ring Underow adapter"
   :url "http://github.com/luminus-framework/ring-adapter-undertow"
   :license {:name "ISC License"

--- a/src/ring/adapter/undertow/request.clj
+++ b/src/ring/adapter/undertow/request.clj
@@ -9,7 +9,8 @@
   [^HttpServerExchange exchange]
   (let [headers (.getRequestHeaders exchange)
         ctype   (.getFirst headers Headers/CONTENT_TYPE)]
-    {:server-port        (-> exchange .getDestinationAddress .getPort)
+    {:server-exchange    exchange
+     :server-port        (-> exchange .getDestinationAddress .getPort)
      :server-name        (-> exchange .getHostName)
      :remote-addr        (-> exchange .getSourceAddress .getAddress .getHostAddress)
      :uri                (-> exchange .getRequestURI)


### PR DESCRIPTION
Added HttpServerExchange to request map under ```:server-exchange``` key. 

Found another usage of ```:server-exchange``` as a key [here](https://github.com/luminus-framework/ring-undertow-adapter/blob/master/src/ring/adapter/undertow/middleware/session.clj#L76).