### PR TITLE
Fix reflection warning

### DIFF
--- a/src/ring/adapter/undertow.clj
+++ b/src/ring/adapter/undertow.clj
@@ -58,7 +58,7 @@
                                                           :body   (.getMessage exception)})))))))))
 
 (defn ^:no-doc handler!
-  [handler builder {:keys [dispatch? handler-proxy websocket? async? session-manager?
+  [handler ^Undertow$Builder builder {:keys [dispatch? handler-proxy websocket? async? session-manager?
                            max-sessions server-name custom-manager]
                     :or   {dispatch?        true
                            websocket?       true


### PR DESCRIPTION
Gets rid of this one:

```
Reflection warning, ring/adapter/undertow.clj:85:14 - call to method setHandler can't be resolved (target class is unknown).
```