### PR TITLE
Use Undertow onClose semantics, fixes client Close frame hang

### DIFF
--- a/test/ring/adapter/test/undertow.clj
+++ b/test/ring/adapter/test/undertow.clj
@@ -123,8 +123,10 @@
 
   (testing "websockets"
     (let [events  (atom [])
+          ws-ch   (atom nil)
           result  (promise)
-          ws-opts {:on-open    (fn [_]
+          ws-opts {:on-open    (fn [{:keys [channel]}]
+                                 (reset! ws-ch channel)
                                  (swap! events conj :open))
                    :on-message (fn [{:keys [data]}]
                                  (swap! events conj data))
@@ -134,7 +136,9 @@
         (let [socket (gniazdo/connect "ws://localhost:4347/")]
           (gniazdo/send-msg socket "hello")
           (gniazdo/close socket))
-        (is (= [:open "hello" :close] (deref result 2000 :fail))))))
+        (is (= [:open "hello" :close] (deref result 2000 :fail)))
+        (is (.isCloseFrameReceived @ws-ch) "Client close received")
+        (is (.isCloseFrameSent @ws-ch) "Client close acknowledged"))))
 
   (testing "websocket custom headers"
     (let [result  (promise)]

--- a/test/ring/adapter/test/undertow.clj
+++ b/test/ring/adapter/test/undertow.clj
@@ -125,13 +125,13 @@
     (let [events  (atom [])
           ws-ch   (atom nil)
           result  (promise)
-          ws-opts {:on-open    (fn [{:keys [channel]}]
-                                 (reset! ws-ch channel)
-                                 (swap! events conj :open))
-                   :on-message (fn [{:keys [data]}]
-                                 (swap! events conj data))
-                   :on-close   (fn [_]
-                                 (deliver result (swap! events conj :close)))}]
+          ws-opts {:on-open          (fn [{:keys [channel]}]
+                                       (reset! ws-ch channel)
+                                       (swap! events conj :open))
+                   :on-message       (fn [{:keys [data]}]
+                                       (swap! events conj data))
+                   :on-close-message (fn [_]
+                                       (deliver result (swap! events conj :close)))}]
       (with-server (websocket-handler ws-opts) {:port test-port}
         (let [socket (gniazdo/connect "ws://localhost:4347/")]
           (gniazdo/send-msg socket "hello")


### PR DESCRIPTION
There is a bug in AbstractReceiveListener.

## Foreword

The proposed solution is strict. A breaking change that will throw on AssertionError for users of `:on-close`.
But I am happy to discuss further how people think this should be handled.

At least Sente users will not be affected, as the default Undertow adapter doesn't use `:on-close`: https://github.com/ptaoussanis/sente/blob/master/src/taoensso/sente/server_adapters/undertow.clj#L31

## Description

As the proxy overrides the default implementation of AbstractReceiveListener, it discards built-in 'onClose' logic of Undertow.
The Undertow implementation contains proper logic to send close frame back to client, when client notifies the server of close.

Our current version of AbstractReceiveListener results in client 'hanging', waiting for the 'response' close frame from Undertow. Basically, it violates the WS spec:
>Once an endpoint has both sent and received a Close control frame, that endpoint SHOULD Close the WebSocket Connection as defined in Section 7.1.1.

This was pretty easily revealed by adding a test assertion, which after client close, asks the WebSocketChannel if the method `isCloseFrameSent` returns true.
It did not. Because the test's `:on-close` handler did not for example call [sendClose](https://undertow.io/javadoc/2.1.x/io/undertow/websockets/core/WebSocketChannel.html#sendClose--). I doubt how many users of this library realise to do it by hand.

## Undertow default onClose

When Undertow [receives](https://github.com/undertow-io/undertow/blob/2.2.19.Final/core/src/main/java/io/undertow/websockets/core/AbstractReceiveListener.java#L38) the close frame, the default onClose would eventually lead to [onFullCloseMessage](https://github.com/undertow-io/undertow/blob/2.2.19.Final/core/src/main/java/io/undertow/websockets/core/AbstractReceiveListener.java#L185) method of the aforementioned AbstractReceiveListener class. 
`onFullCloseMessage` sends a proper close message back to client that initiated the close comms. That happens [here](https://github.com/undertow-io/undertow/blob/master/core/src/main/java/io/undertow/websockets/core/AbstractReceiveListener.java#L191).

I think it is slightly inconvenient that Undertow has lifted the spec implementation responsibility to 'listener', although provides default implementation to it. 
Issue #18 references kind-of-related issue, that has recently been fixed in Undertow. But it doesn't address the issue raised in this PR. Those who extend AbstractReceiveListener and override methods its methods are "on their own", to handle spec semantics it seems.

IMO clients of this library should mostly be interested in `onCloseMessage`.
Keeping `onClose` as it was would lift the impl details and caveats to the users of this library. 
Our team had this locally monkey patched via Sente adapter, but I think leaning on Undertow here would be safest in the long run.
We would not need to know about `onClose` peculiarities and potential future breaking changes in how Undertow handles the comms.