### PR TITLE
make wrap-undertow-session async aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 /.idea
 *.iml
 .nrepl-port
+/.clj-kondo/.cache/
+/.lsp/.cache/

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject luminus/ring-undertow-adapter "1.2.7"
+(defproject luminus/ring-undertow-adapter "1.2.8-SNAPSHOT"
   :description "Ring Undertow adapter"
   :url "http://github.com/luminus-framework/ring-adapter-undertow"
   :license {:name "MIT License"


### PR DESCRIPTION
I've been trying to use luminus with async ring handlers, this adds the missing 3 argument handler to wrap-undertow-session.
