### PR TITLE
feat: add graceful shutdown support, returning UndertowWrapper object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0 - December xx, 2024
+- BREAKING: `run-undertow` now returns an `UndertowWrapper` object. The method proxies all original Undertow methods. However, it cannot be cast to Undertow itself. To get the original Undertow object, you can access it via the `getUndertow` method
+- Add support for graceful shutdown option. When `:graceful-shutdown-timeout` passed in will add graceful shutdown handler. [PR xx](TODO)
+- Bump to undertow-core 2.4.0.Final
+- Bump to ring-core 1.13.0 (note: consider adding new Ring WebSocket API in future release)
+
 ## 1.3.0 - November 29, 2022
 
 - Bump to undertow-core 2.3.0.Final

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject luminus/ring-undertow-adapter "1.3.1"
+(defproject luminus/ring-undertow-adapter "1.4.0"
   :description "Ring Undertow adapter"
   :url "http://github.com/luminus-framework/ring-adapter-undertow"
   :license {:name "MIT License"
             :url  "http://opensource.org/licenses/MIT"}
-  :dependencies [[io.undertow/undertow-core "2.3.5.Final"]
-                 [ring/ring-core "1.9.6"]]
+  :dependencies [[io.undertow/undertow-core "2.3.12.Final"]
+                 [ring/ring-core "1.13.0"]]
   :profiles {:dev     {:dependencies [[org.clojure/clojure "1.11.1"]
                                       [clj-http "3.12.3"]
                                       [stylefruits/gniazdo "1.2.1"]

--- a/src/ring/adapter/undertow/UndertowWrapper.java
+++ b/src/ring/adapter/undertow/UndertowWrapper.java
@@ -1,0 +1,92 @@
+package ring.adapter.undertow;
+
+import io.undertow.Undertow;
+import io.undertow.UndertowLogger;
+import io.undertow.server.handlers.GracefulShutdownHandler;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
+
+import java.util.List;
+
+/**
+ * A wrapper for Undertow server that provides graceful shutdown capabilities
+ * while maintaining all original Undertow functionality.
+ */
+public final class UndertowWrapper {
+    private final Undertow undertow;
+    private final GracefulShutdownHandler gracefulShutdown;
+    private final Long shutdownTimeout;
+
+    /**
+     * Creates a new UndertowWrapper with graceful shutdown support.
+     *
+     * @param undertow The Undertow server instance to wrap
+     * @param gracefulShutdown The graceful shutdown handler (optional)
+     * @param shutdownTimeout Timeout in milliseconds for graceful shutdown (optional)
+     * @throws IllegalArgumentException if undertow is null
+     */
+    public UndertowWrapper(Undertow undertow, GracefulShutdownHandler gracefulShutdown, Long shutdownTimeout) {
+        if (undertow == null) {
+            throw new IllegalArgumentException("Undertow instance cannot be null");
+        }
+        this.undertow = undertow;
+        this.gracefulShutdown = gracefulShutdown;
+        this.shutdownTimeout = shutdownTimeout;
+    }
+
+    /**
+     * Creates a new UndertowWrapper without graceful shutdown support.
+     *
+     * @param undertow The Undertow server instance to wrap
+     * @throws IllegalArgumentException if undertow is null
+     */
+    public UndertowWrapper(Undertow undertow) {
+        this(undertow, null, null);
+    }
+
+    public void stop() {
+        if (gracefulShutdown != null) {
+            try {
+                // initiate graceful shutdown
+                UndertowLogger.ROOT_LOGGER.info("Attempting graceful Undertow handler shutdown");
+                gracefulShutdown.shutdown();
+                if (shutdownTimeout != null) {
+                    gracefulShutdown.awaitShutdown(shutdownTimeout);
+                }
+            } catch (Exception e) {
+                if (shutdownTimeout != null) {
+                    UndertowLogger.ROOT_LOGGER.errorf("Graceful shutdown timed out after %s, stopping Undertow", shutdownTimeout);
+                }
+
+                UndertowLogger.ROOT_LOGGER.error("Failed to gracefully shutdown, stopping Undertow");
+            } finally {
+                undertow.stop();
+            }
+        } else {
+            undertow.stop();
+        }
+    }
+
+    // exposed in case the original Undertow object is required
+    public Undertow getUndertow() {
+        return undertow;
+    }
+
+    public void start() {
+        undertow.start();
+    }
+
+    public Xnio getXnio() {
+        return undertow.getXnio();
+    }
+
+    public XnioWorker getWorker() {
+        return undertow.getWorker();
+    }
+
+    public List<Undertow.ListenerInfo> getListenerInfo() {
+        return undertow.getListenerInfo();
+    }
+}
+
+


### PR DESCRIPTION
Resolves https://github.com/luminus-framework/ring-undertow-adapter/issues/33

Note: this is a breaking change in Java-land, since the object returned is an UndertowWrapper class and not an Undertow class. We sadly cannot proxy Undertow as it is final. An interface or other delegation doesn't work for the same reason.

The option here is to create a wrapper class that exposes all the public methods from Undertow as the same. However, since Undertow is public we still cannot cast to it. As a result, we add a new method `getUndertow` which returns the original object.

Projects which use this lib and don't check explicitly for the class match should be unaffected so I think it is a low risk breaking change.