### PR TITLE
fix: handle numbers as header values

### DIFF
--- a/src/ring/adapter/undertow/headers.clj
+++ b/src/ring/adapter/undertow/headers.clj
@@ -22,9 +22,9 @@
   (reduce-kv
     (fn [^HeaderMap header-map ^String key val-or-vals]
       (let [key (HttpString. key)]
-        (if (string? val-or-vals)
-          (.put header-map key ^String val-or-vals)
-          (.putAll header-map key val-or-vals)))
+        (if (or (sequential? val-or-vals) (set? val-or-vals))
+          (.putAll header-map key val-or-vals)
+          (.put header-map key ^String (str val-or-vals))))
       header-map)
     header-map
     headers))

--- a/test/ring/adapter/test/undertow.clj
+++ b/test/ring/adapter/test/undertow.clj
@@ -211,6 +211,34 @@
                          "text/plain"))
         (is (= (:body response) "Hello World"))))))
 
+(deftest number-header-test
+  (testing "integer header values should work"
+    (let [handler-with-int-headers (fn [_]
+                                     {:status  200
+                                      :headers {"X-Int"        (int 10)
+                                                "X-Long"       (long 42)}
+                                      :body    "hello"})]
+      (with-server handler-with-int-headers {:port test-port}
+        (let [response (http/get test-url)]
+          (is (= (:status response) 200))
+          (is (= (get-in response [:headers "x-int"]) "10"))
+          (is (= (get-in response [:headers "x-long"]) "42")))))))
+
+
+(deftest collection-headers-test
+  (testing "set or list headers should work"
+    (let [handler-with-int-headers (fn [_]
+                                     {:status  200
+                                      :headers {"banana"        ["a" "b"]
+                                                "apple"         #{"x" "y"}}
+                                      :body    "hello"})]
+      (with-server handler-with-int-headers {:port test-port}
+        (let [response (http/get test-url)]
+          (is (= (:status response) 200))
+          (is (= (get-in response [:headers "banana"]) ["a" "b"]))
+          (is (= (get-in response [:headers "apple"]) ["x" "y"])))))))
+
+
 (deftest undertow-graceful-shutdown-test
   (testing "graceful shutdown"
     (let [sleep-handler (fn [_]
@@ -231,5 +259,4 @@
         (println "Graceful stop called")
         (let [response (deref future-resp)]
           (is (= (:status response) 200))
-          (is (= (:body response) "Hello World")))))
-    ))
+          (is (= (:body response) "Hello World")))))))


### PR DESCRIPTION
This will just cast everything to string, which may be odd in case you give it a map, or random java object. But in many cases I'll guess it'd be ok.

Fixes
https://github.com/luminus-framework/ring-undertow-adapter/issues/37