### PR TITLE
Add support for concurrent request limits and queue size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.4
+- [add :queue-size and :concurrent-requests options](https://github.com/luminus-framework/ring-undertow-adapter/pull/43)
+
 ## 1.4.3
 - [add gzip middleware using Undertow GzipEncodingProvider](https://github.com/luminus-framework/ring-undertow-adapter/pull/42)
 

--- a/README.md
+++ b/README.md
@@ -14,38 +14,63 @@ ring-undertow-adapter is a [Ring](https://github.com/ring-clojure/ring) server b
 HTTP handler returns an Undertow server instance. To stop call `(.stop <handler instance>)`.
 The handler is initialized using a map with the following keys:
 
-* `:configurator` - a function called with the Undertow Builder instance
-* `:host` - the hostname to listen on
-* `:http?` - flag to enable http (defaults to true)
-* `:port` - the port to listen on (defaults to 80)
-* `:ssl-port` - a number, requires either :ssl-context, :keystore, or :key-managers
-* `:keystore` - the filepath (a String) to the keystore
-* `:key-password` - the password for the keystore
-* `:truststore` - if separate from the keystore
-* `:trust-password` - if :truststore passed
-* `:ssl-context` - a valid javax.net.ssl.SSLContext
-* `:key-managers` - a valid javax.net.ssl.KeyManager []
-* `:trust-managers` - a valid javax.net.ssl.TrustManager []
-* `:client-auth` - SSL client authentication mode. Can be `:want`/`:requested` or `:need`/`:required`
-* `:http2?` - a flag to enable http2. Boolean
-* `:io-threads` -  # threads handling IO, defaults to available processors
-* `:concurrent-requests` - maximum # of requests that can be processed concurrently (default: nil, unlimited)
-* `:queue-size` - maximum # of requests that can be queued when concurrent limit is reached (default: nil, unlimited queue). Requires `:concurrent-requests` to be set. When the queue is full, requests receive a 503 status.
-* `:worker-threads` - # threads invoking handlers, defaults to `:concurrent-requests` if set, otherwise to (* io-threads 8)
-* `:buffer-size` - a number, defaults to 16k for modern servers
-* `:direct-buffers?` - boolean, defaults to true
-* `:dispatch?`      - dispatch handlers off the I/O threads (default: true)
-* `:websocket?` - built-in handler support for websocket callbacks
-* `:async?` - ring async flag. When true, expect a ring async three arity handler function
-* `:handler-proxy` - an optional custom handler proxy function taking handler as single argument
-* `:max-entity-size`  - maximum size of a request entity
-* `:session-manager?` - initialize undertow session manager (default: true)
-* `:custom-manager`   - custom implementation that extends the io.undertow.server.session.SessionManager interface. Only used if `:session-manager?` is true. If not provided, defaults to Undertow inmemory SessionManager
-* `:max-sessions`     - maximum number of undertow sessions, for use with InMemorySessionManager (default: -1)
-* `:server-name`      - for use with InMemorySessionManager (default: "ring-undertow")
-* `:graceful-shutdown-timeout` - timeout for graceful shutdown in milliseconds (default: nil, no graceful shutdown)
-* `:gzip?` - flag to enable gzip compression (default: false)
+#### Network
 
+| Key | Default | Info |
+|-----|---------|------|
+| `:host` | `localhost` | The hostname to listen on. (Set to `0.0.0.0` to be reachable from the wider internet)  |
+| `:http?` | `true` | Flag to enable HTTP |
+| `:port` | `80` | The port to listen on |
+| `:http2?` | `false` | Flag to enable HTTP/2 |
+| `:gzip?` | `false` | Flag to enable gzip compression |
+
+#### SSL
+
+| Key | Default | Info |
+|-----|---------|------|
+| `:ssl-port` | - | SSL port number (requires `:ssl-context`, `:keystore`, or `:key-managers`) |
+| `:keystore` | - | Filepath (String) to the keystore |
+| `:key-password` | - | Password for the keystore |
+| `:truststore` | - | Truststore if separate from the keystore |
+| `:trust-password` | - | Password for the truststore |
+| `:ssl-context` | - | Valid `javax.net.ssl.SSLContext` |
+| `:key-managers` | - | Valid `javax.net.ssl.KeyManager[]` |
+| `:trust-managers` | - | Valid `javax.net.ssl.TrustManager[]` |
+| `:client-auth` | - | SSL client authentication mode: `:want`/`:requested` or `:need`/`:required` |
+
+#### Concurrency
+
+| Key | Default | Info |
+|-----|---------|------|
+| `:concurrent-requests` | `nil` (unlimited) | Maximum number of requests that can be processed concurrently |
+| `:queue-size` | `nil` (unlimited) | Maximum number of requests that can be queued when concurrent limit is reached. Requires `:concurrent-requests` to be set. When the queue is full, requests receive a 503 status |
+| `:worker-threads` | `:concurrent-requests` if set, else `(* io-threads 8)` | Number of threads invoking handlers |
+| `:graceful-shutdown-timeout` | `nil` (no graceful shutdown) | Timeout for graceful shutdown in milliseconds |
+
+#### Performance
+
+| Key | Default | Info |
+|-----|---------|------|
+| `:io-threads` | Available processors | Number of threads handling I/O |
+| `:buffer-size` | `16k` | Buffer size for modern servers |
+| `:direct-buffers?` | `true` | Use direct buffers |
+| `:dispatch?` | `true` | Dispatch handlers off the I/O threads |
+| `:max-entity-size` | - | Maximum size of a request entity |
+
+#### Misc
+
+| Key | Default | Info |
+|-----|---------|------|
+| `:configurator` | - | Function called with the Undertow Builder instance |
+| `:websocket?` | `true` | Built-in handler support for websocket callbacks |
+| `:async?` | `false` | Ring async flag. When true, expect a ring async three arity handler function |
+| `:handler-proxy` | - | Optional custom handler proxy function taking handler as single argument |
+| `:session-manager?` | `true` | Initialize Undertow session manager |
+| `:custom-manager` | - | Custom implementation that extends `io.undertow.server.session.SessionManager` interface. Only used if `:session-manager?` is true. If not provided, defaults to Undertow InMemorySessionManager |
+| `:max-sessions` | `-1` | Maximum number of Undertow sessions, for use with InMemorySessionManager |
+| `:server-name` | `"ring-undertow"` | Server name for use with InMemorySessionManager |
+
+### Code example
 
 ```clojure
 (require '[ring.adapter.undertow :refer [run-undertow]])
@@ -134,7 +159,7 @@ Request limiting controls concurrent request processing and queueing to protect 
 
 To enable, set `:concurrent-requests` and `:queue-size` options. When the queue is full, backpressure will be applied in the form of status 503 responses.
 
-`:worker-threads` should not need to be set if you have `:concurrent-requests`, unless you're doing asyncronous requests.
+`:worker-threads` should not need to be set if you have `:concurrent-requests`, unless you're doing asynchronous requests.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ The handler is initialized using a map with the following keys:
 * `:trust-managers` - a valid javax.net.ssl.TrustManager []
 * `:client-auth` - SSL client authentication mode. Can be `:want`/`:requested` or `:need`/`:required`
 * `:http2?` - a flag to enable http2. Boolean
-* `:io-threads` - # threads handling IO, defaults to available processors
-* `:worker-threads` - # threads invoking handlers, defaults to (* io-threads 8)
+* `:io-threads` -  # threads handling IO, defaults to available processors
+* `:concurrent-requests` - maximum # of requests that can be processed concurrently (default: nil, unlimited)
+* `:queue-size` - maximum # of requests that can be queued when concurrent limit is reached (default: nil, unlimited queue). Requires `:concurrent-requests` to be set. When the queue is full, requests receive a 503 status.
+* `:worker-threads` - # threads invoking handlers, defaults to `:concurrent-requests` if set, otherwise to (* io-threads 8)
 * `:buffer-size` - a number, defaults to 16k for modern servers
 * `:direct-buffers?` - boolean, defaults to true
 * `:dispatch?`      - dispatch handlers off the I/O threads (default: true)
@@ -43,6 +45,7 @@ The handler is initialized using a map with the following keys:
 * `:server-name`      - for use with InMemorySessionManager (default: "ring-undertow")
 * `:graceful-shutdown-timeout` - timeout for graceful shutdown in milliseconds (default: nil, no graceful shutdown)
 * `:gzip?` - flag to enable gzip compression (default: false)
+
 
 ```clojure
 (require '[ring.adapter.undertow :refer [run-undertow]])
@@ -124,6 +127,14 @@ Compression is automatically applied only to:
 
 (run-undertow handler {:port 8080 :gzip? true})
 ```
+
+### Request Limiting
+
+Request limiting controls concurrent request processing and queueing to protect your server from overload, and allow quick recovery afterwards.
+
+To enable, set `:concurrent-requests` and `:queue-size` options. When the queue is full, backpressure will be applied in the form of status 503 responses.
+
+`:worker-threads` should not need to be set if you have `:concurrent-requests`, unless you're doing asyncronous requests.
 
 ## License
 

--- a/src/ring/adapter/undertow.clj
+++ b/src/ring/adapter/undertow.clj
@@ -11,7 +11,7 @@
     [org.xnio Options SslClientAuthMode]
     [io.undertow.server HttpHandler]
     [io.undertow.server.handlers BlockingHandler
-                                 GracefulShutdownHandler]
+                                 GracefulShutdownHandler RequestLimitingHandler]
     [io.undertow.server.session SessionAttachmentHandler
                                 SessionCookieConfig
                                 SessionManager InMemorySessionManager]
@@ -60,12 +60,20 @@
                          (set-exchange-response exchange {:status 500
                                                           :body   (.getMessage exception)})))))))))
 
+(defn ^:no-doc wrap-with-req-limiter [concurrent-requests queue-size handler]
+  (when (and queue-size (not concurrent-requests))
+    ; If concurrent-requests isn't bounded, queue-size won't have any effect
+    (throw (IllegalArgumentException. ":queue-size requires :concurrent-requests to be set")))
+  (RequestLimitingHandler. concurrent-requests
+                           (or queue-size -1) ; -1 means unbounded queue
+                           handler))
+
+
 (defn ^:no-doc handler!
-  [handler ^Undertow$Builder {:keys [dispatch? handler-proxy websocket? async? session-manager?
+  [handler ^Undertow$Builder {:keys [dispatch? handler-proxy async? session-manager?
                                      max-sessions server-name custom-manager graceful-shutdown-timeout
-                                     gzip?]
+                                     gzip? concurrent-requests queue-size]
                               :or   {dispatch?        true
-                                     websocket?       true
                                      async?           false
                                      session-manager? true
                                      max-sessions     -1
@@ -83,7 +91,10 @@
                                             (InMemorySessionManager. (str server-name "-session-manager") max-sessions)))
 
              gzip?
-             (wrap-with-gzip-handler {})
+             (wrap-with-gzip-handler)
+
+             (or queue-size concurrent-requests)
+             (wrap-with-req-limiter concurrent-requests queue-size)
 
              (and (nil? handler-proxy)
                   dispatch?)
@@ -93,11 +104,11 @@
              (GracefulShutdownHandler.))))
 
 (defn ^:no-doc tune!
-  [^Undertow$Builder builder {:keys [io-threads worker-threads buffer-size direct-buffers? max-entity-size]}]
+  [^Undertow$Builder builder {:keys [io-threads concurrent-requests worker-threads buffer-size direct-buffers? max-entity-size]}]
   (cond-> builder
           max-entity-size (.setServerOption UndertowOptions/MAX_ENTITY_SIZE (long max-entity-size))
           io-threads (.setIoThreads io-threads)
-          worker-threads (.setWorkerThreads worker-threads)
+          worker-threads (.setWorkerThreads (or worker-threads concurrent-requests))
           buffer-size (.setBufferSize buffer-size)
           (not (nil? direct-buffers?)) (.setDirectBuffers direct-buffers?)))
 
@@ -143,8 +154,10 @@
   :trust-managers            - a valid javax.net.ssl.TrustManager []
   :client-auth                - SSL client authentication mode. Can be :want/:requested or :need/:required
   :http2?                    - flag to enable http2
+  :concurrent-requests       - maximum number of requests processed concurrently (default: nil, unlimited)
+  :queue-size                - maximum queued requests when limit is reached (default: nil, unlimited). Requires :concurrent-requests
   :io-threads                - # threads handling IO, defaults to available processors
-  :worker-threads            - # threads invoking handlers, defaults to (* io-threads 8)
+  :worker-threads            - # threads invoking handlers, defaults to :concurrent-requests if set, else (* io-threads 8)
   :buffer-size               - a number, defaults to 16k for modern servers
   :direct-buffers?           - boolean, defaults to true
   :dispatch?                 - dispatch handlers off the I/O threads (default: true)

--- a/src/ring/adapter/undertow/middleware/gzip.clj
+++ b/src/ring/adapter/undertow/middleware/gzip.clj
@@ -17,12 +17,10 @@
   - Client accepts gzip encoding via Accept-Encoding header
   
   Returns an HttpHandler that automatically compresses eligible responses with gzip."
-  ([^HttpHandler handler]
-   (wrap-with-gzip-handler {} handler))
-  ([_ ^HttpHandler handler]
-   (let [gzip-provider (GzipEncodingProvider.)
-         ;; Predicate: minimum 1KB size AND compressible content type
-         predicate (Predicates/parse "max-content-size(1) and regex(pattern='text/.*|application/(json|javascript|xml|.*\\\\+xml)|image/svg.*', value=%{o,Content-Type})")
-         encoding-repo (doto (ContentEncodingRepository.)
+  [^HttpHandler handler]
+  (let [gzip-provider (GzipEncodingProvider.)
+        ;; Predicate: minimum 1KB size AND compressible content type
+        predicate     (Predicates/parse "max-content-size(1) and regex(pattern='text/.*|application/(json|javascript|xml|.*\\\\+xml)|image/svg.*', value=%{o,Content-Type})")
+        encoding-repo (doto (ContentEncodingRepository.)
                         (.addEncodingHandler "gzip" gzip-provider 100 predicate))]
-     (EncodingHandler. handler encoding-repo))))
+    (EncodingHandler. handler encoding-repo)))

--- a/test/ring/adapter/test/undertow.clj
+++ b/test/ring/adapter/test/undertow.clj
@@ -249,15 +249,42 @@
                              (println "Done work")
                              {:status  200
                               :headers {"Content-Type" "text/plain"}
-                              :body    "Hello World"}))]
-      (let [server      (run-undertow sleep-handler {:port                      test-port
-                                                     :graceful-shutdown-timeout 1000})
-            future-resp (future (http/get test-url))]
-        (Thread/sleep 10)
-        (println "Graceful stop started")
-        (.stop server)
-        (println "Graceful stop called")
-        (let [response (deref future-resp)]
-          (is (= (:status response) 200))
-          (is (= (:body response) "Hello World")))))))
+                              :body    "Hello World"}))
+          server      (run-undertow sleep-handler {:port                      test-port
+                                                   :graceful-shutdown-timeout 1000})
+          future-resp (future (http/get test-url))]
+      (Thread/sleep 10)
+      (println "Graceful stop started")
+      (.stop server)
+      (println "Graceful stop called")
+      (let [response (deref future-resp)]
+        (is (= (:status response) 200))
+        (is (= (:body response) "Hello World"))))))
 
+(deftest concurrent-request-limiting-test
+  (testing "You have to set :concurrent-requests if you set :queue-size"
+    (is (thrown? IllegalArgumentException
+                 (run-undertow (fn [_] {:status 200 :body "OK"})
+                               {:port       test-port
+                                :queue-size 1}))))
+
+  (let [processed (atom 0)
+        latch     (promise)]
+    (with-server (fn [_]
+                   (swap! processed inc)
+                   (deref latch 500 :timeout) ;; Block until we release all requests
+                   {:status 200 :body "OK"})
+                 {:port                test-port
+                  :concurrent-requests 1
+                  :queue-size          1}
+      (let [r1 (future (http/get test-url))
+            _  (Thread/sleep 10)
+            r2 (future (http/get test-url))
+            _  (Thread/sleep 10)
+            r3 (future (http/get test-url {:throw-exceptions false}))]
+        (Thread/sleep 10)
+        (is (= @processed 1))
+        (is (= (:status (deref r3 100 :timeout)) 503))
+        (deliver latch true)
+        (is (= (:status (deref r1 100 :timeout)) 200))
+        (is (= (:status (deref r2 100 :timeout)) 200))))))


### PR DESCRIPTION
Fixes https://github.com/luminus-framework/ring-undertow-adapter/issues/39
Works fine as is, but it seems odd that this kinda but not really duplicates the :worker-threads option. I need to think though, or discuss, how that should work. I feel like there might be an obvious answer.
Also cleaned some minor things, I can split that out into a separate commit, or skip it depending on your thoughts.