### PR TITLE
Update docs to explain units of max-entity-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The handler is initialized using a map with the following keys:
 | `:buffer-size` | `16k` | Buffer size for modern servers |
 | `:direct-buffers?` | `true` | Use direct buffers |
 | `:dispatch?` | `true` | Dispatch handlers off the I/O threads |
-| `:max-entity-size` | - | Maximum size of a request entity |
+| `:max-entity-size` | `nil` (unlimited) | Maximum size of the request body in bytes |
 
 #### Misc
 

--- a/src/ring/adapter/undertow.clj
+++ b/src/ring/adapter/undertow.clj
@@ -164,7 +164,7 @@
   :websocket?                - built-in handler support for websocket callbacks
   :async?                    - ring async flag. When true, expect a ring async three arity handler function
   :handler-proxy             - an optional custom handler proxy function taking handler as single argument
-  :max-entity-size           - maximum size of a request entity
+  :max-entity-size           - maximum size of the request body in bytes (default: unlimited)
   :session-manager?          - initialize undertow session manager (default: true)
   :custom-manager            - custom implementation that extends the io.undertow.server.session.SessionManager interface
   :max-sessions              - maximum number of undertow session, for use with InMemorySessionManager (default: -1)


### PR DESCRIPTION
I had to dig into the code to find out what this was. I was also confused by it not working in testing so I added an explanation of what it limits (only body).

Thought I'd help someone else by adding this to the docs.